### PR TITLE
Generate a JSON file for each EAD to allow for manifest generation before the job completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# archivesspace_export_service
+
+The ArchivesSpace Export Service provides a framework for scheduled EAD export and publication.
+It consists of an ArchivesSpace plug-in and an application that uses the ArchivesSpace API but
+which is otherwise independent of ArchivesSpace and can be deployed anywhere so long as it has
+access to the ArchivesSpace backend.
+
+The ArchivesSpace Export Service was developed by Hudson Molonglo for Yale University.
+

--- a/backend/model/resource_update_monitor.rb
+++ b/backend/model/resource_update_monitor.rb
@@ -1,5 +1,7 @@
 class ResourceUpdateMonitor
 
+  include JSONModel
+
   def initialize()
     @repo_id = nil
     @start_id = nil
@@ -64,15 +66,17 @@ class ResourceUpdateMonitor
         mods = mods.where(:identifier => @start_id)
       end
 
-      mods = mods.select(:id, :identifier, :repo_id, :publish, :suppressed)
+      mods = mods.select(:id, :title, :identifier, :repo_id, :publish, :suppressed)
 
       mods.each do |res|
         if in_range(res)
           if res[:publish] == 1 && res[:suppressed] == 0
             adds << {
               'id' => res[:id],
+              'title' => res[:title],
               'identifier' => JSON.parse(res[:identifier]),
-              'repo_id' => res[:repo_id]
+              'repo_id' => res[:repo_id],
+              'uri' => JSONModel(:resource).uri_for(res[:id], :repo_id => res[:repo_id]),
             }
           else
             removes << res[:id]

--- a/exporter_app/config/jobs.rb
+++ b/exporter_app/config/jobs.rb
@@ -11,7 +11,7 @@
     WeekdayJob.new(:job_identifier => '001',
                    :job_name => 'Every morning',
                    :days_of_week => ['Mon', 'Tue', 'Wed', 'Fri'],
-                   :start_time => '12:00',
+                   :start_time => '10:00',
                    :end_time => '6:00',
 
                    :task => ExportEADTask,

--- a/exporter_app/tasks/lib/sqlite_work_queue.rb
+++ b/exporter_app/tasks/lib/sqlite_work_queue.rb
@@ -24,7 +24,7 @@ class SQLiteWorkQueue
   def next
     with_connection do |conn|
       prepare(conn,
-              "select id, resource_id, action, identifier, repo_id from work_queue order by id limit 1") do |statement|
+              "select id, resource_id, action, identifier, repo_id, title, uri from work_queue order by id limit 1") do |statement|
         rs = statement.execute_query
         while rs.next
           return {
@@ -33,6 +33,8 @@ class SQLiteWorkQueue
             :action => rs.get_string(3),
             :identifier => rs.get_string(4),
             :repo_id => rs.get_int(5),
+            :title => rs.get_string(5),
+            :uri => rs.get_string(5),
           }
         end
       end
@@ -156,7 +158,8 @@ class SQLiteWorkQueue
       statement = conn.create_statement
       statement.execute_update("create table if not exists work_queue" +
                                " (id integer primary key autoincrement," +
-                               " action text, resource_id integer, identifier text, repo_id integer)")
+                               " action text, resource_id integer, identifier text," +
+                               " repo_id integer, title text, uri text)")
 
       statement.execute_update("create table if not exists status" +
                                " (key primary key, int_value integer)")

--- a/exporter_app/tasks/lib/sqlite_work_queue.rb
+++ b/exporter_app/tasks/lib/sqlite_work_queue.rb
@@ -33,8 +33,8 @@ class SQLiteWorkQueue
             :action => rs.get_string(3),
             :identifier => rs.get_string(4),
             :repo_id => rs.get_int(5),
-            :title => rs.get_string(5),
-            :uri => rs.get_string(5),
+            :title => rs.get_string(6),
+            :uri => rs.get_string(7),
           }
         end
       end


### PR DESCRIPTION
1. adds title and uri to the plugin service and also to the work queue item
1. generates a JSON file with id, title and uri alongside the EAD xml.  The idea that once combined with the github content, we can grab all json files and generate a single HTML manifest file from these JSON files (assuming it's ok to commit both the JSON and XML???).