### PR TITLE
Generate a JSON file for each EAD to allow for manifest generation as the job completes

### DIFF
--- a/backend/model/resource_update_monitor.rb
+++ b/backend/model/resource_update_monitor.rb
@@ -1,5 +1,7 @@
 class ResourceUpdateMonitor
 
+  include JSONModel
+
   def initialize()
     @repo_id = nil
     @start_id = nil
@@ -64,15 +66,17 @@ class ResourceUpdateMonitor
         mods = mods.where(:identifier => @start_id)
       end
 
-      mods = mods.select(:id, :identifier, :repo_id, :publish, :suppressed)
+      mods = mods.select(:id, :title, :identifier, :repo_id, :publish, :suppressed)
 
       mods.each do |res|
         if in_range(res)
           if res[:publish] == 1 && res[:suppressed] == 0
             adds << {
               'id' => res[:id],
+              'title' => res[:title],
               'identifier' => JSON.parse(res[:identifier]),
-              'repo_id' => res[:repo_id]
+              'repo_id' => res[:repo_id],
+              'uri' => JSONModel(:resource).uri_for(res[:id], :repo_id => res[:repo_id]),
             }
           else
             removes << res[:id]

--- a/exporter_app/config/jobs.rb
+++ b/exporter_app/config/jobs.rb
@@ -11,7 +11,7 @@
     WeekdayJob.new(:job_identifier => '001',
                    :job_name => 'Every morning',
                    :days_of_week => ['Mon', 'Tue', 'Wed', 'Fri'],
-                   :start_time => '12:00',
+                   :start_time => '10:00',
                    :end_time => '6:00',
 
                    :task => ExportEADTask,

--- a/exporter_app/tasks/export_ead_task.rb
+++ b/exporter_app/tasks/export_ead_task.rb
@@ -27,19 +27,17 @@ class ExportEADTask
     updates = @as_client.updates_since(last_read_time)
 
     load_into_work_queue(updates)
-    create_manifest
 
     while item = @work_queue.next
       if item[:action] == 'add'
         download_ead(item[:resource_id], item[:repo_id])
+        create_manifest_json(item)
       elsif item[:action] == 'remove'
         remove_ead(item[:resource_id])
+        remove_manifest_json(item[:id])
       else
         puts "Unknown action for item: #{item.inspect}"
       end
-
-      update_manifest(item)
-
       @work_queue.done(item)
     end
 
@@ -96,21 +94,23 @@ class ExportEADTask
     # so it's not there, that's cool
   end
 
-  def manifest_json_file
-    File.join(ead_export_directory, "manifest.json")
+  def manifest_json_file(id)
+    File.join(ead_export_directory, "#{id}.json")
   end
 
-  def create_manifest
-    File.open(manifest_json_file, 'w') do |io|
-      io.write([].to_json)
+  def create_manifest_json(item)
+    File.open(manifest_json_file(item[:id]), 'w') do |io|
+      io.write({
+        :id => item[:id],
+        :uri => item[:uri],
+        :title => item[:title],
+      }.to_json)
     end
   end
 
-  def update_manifest(item)
-    ead_file = ead_export_file(item[:id])
-
-    File.open(manifest_json_file, 'w') do |io|
-      # either add or remove item from json
-    end
+  def remove_manifest_json(id)
+    File.delete(manifest_json_file(id))
+  rescue Errno::ENOENT
+    # so it's not there, that's cool
   end
 end

--- a/exporter_app/tasks/lib/sqlite_work_queue.rb
+++ b/exporter_app/tasks/lib/sqlite_work_queue.rb
@@ -24,7 +24,7 @@ class SQLiteWorkQueue
   def next
     with_connection do |conn|
       prepare(conn,
-              "select id, resource_id, action, identifier, repo_id from work_queue order by id limit 1") do |statement|
+              "select id, resource_id, action, identifier, repo_id, title, uri from work_queue order by id limit 1") do |statement|
         rs = statement.execute_query
         while rs.next
           return {
@@ -33,6 +33,8 @@ class SQLiteWorkQueue
             :action => rs.get_string(3),
             :identifier => rs.get_string(4),
             :repo_id => rs.get_int(5),
+            :title => rs.get_string(5),
+            :uri => rs.get_string(5),
           }
         end
       end
@@ -156,7 +158,8 @@ class SQLiteWorkQueue
       statement = conn.create_statement
       statement.execute_update("create table if not exists work_queue" +
                                " (id integer primary key autoincrement," +
-                               " action text, resource_id integer, identifier text, repo_id integer)")
+                               " action text, resource_id integer, identifier text," +
+                               " repo_id integer, title text, uri text)")
 
       statement.execute_update("create table if not exists status" +
                                " (key primary key, int_value integer)")

--- a/exporter_app/tasks/lib/sqlite_work_queue.rb
+++ b/exporter_app/tasks/lib/sqlite_work_queue.rb
@@ -33,8 +33,8 @@ class SQLiteWorkQueue
             :action => rs.get_string(3),
             :identifier => rs.get_string(4),
             :repo_id => rs.get_int(5),
-            :title => rs.get_string(5),
-            :uri => rs.get_string(5),
+            :title => rs.get_string(6),
+            :uri => rs.get_string(7),
           }
         end
       end


### PR DESCRIPTION
Oops.. against the right branch now!

1. adds title and uri to the plugin service and also to the work queue item
1. generates a JSON file with id, title and uri alongside the EAD xml.  The idea that once combined with the github content, we can grab all json files and generate a single HTML manifest file from these JSON files (assuming it's ok to commit both the JSON and XML???).