### PR TITLE
Add ManifestBuilder to outputs a manifest.html generated from an ERB template

### DIFF
--- a/exporter_app/config/jobs.rb
+++ b/exporter_app/config/jobs.rb
@@ -31,6 +31,7 @@
                    ],
 
                    :after_hooks => [
+                     ErbRenderer.new("templates/manifest.html.erb", "manifest.html"),
                      ShellRunner.new("scripts/commit_workspace.sh"),
                    ],
 

--- a/exporter_app/lib/erb_renderer.rb
+++ b/exporter_app/lib/erb_renderer.rb
@@ -1,0 +1,48 @@
+require 'erb'
+require_relative 'hook_interface'
+
+class ErbRenderer < HookInterface
+
+  def initialize(template_file, output_filename)
+    @template_file = template_file
+    @output_filename = output_filename
+  end
+
+  def call(task)
+    export_directory = task.exported_variables.fetch(:export_directory)
+
+    renderer = ERB.new(File.read(@template_file))
+
+    data = TemplateData.new(combined_json(export_directory))
+
+    File.open(output_filename(export_directory), 'w') {|file|
+      file.write(renderer.result(data.get_binding))
+    }
+  end
+
+  private
+
+  class TemplateData
+    def initialize(data)
+      @data = data
+    end
+
+    def get_binding
+      binding()
+    end
+  end
+
+  def combined_json(export_directory)
+    json = []
+
+    Dir.glob(File.join(export_directory, "*.json")) do |filename|
+      json.push(JSON.parse(File.read(filename)))
+    end
+
+    json.sort{|a, b| a[:resource_db_id] <=> b[:resource_db_id]}
+  end
+
+  def output_filename(export_directory)
+    File.join(export_directory, @output_filename)
+  end
+end

--- a/exporter_app/lib/hook_interface.rb
+++ b/exporter_app/lib/hook_interface.rb
@@ -1,0 +1,5 @@
+class HookInterface
+  def call(task)
+    raise NotImplementedError.new("Subclass must implement this")
+  end
+end

--- a/exporter_app/lib/shell_runner.rb
+++ b/exporter_app/lib/shell_runner.rb
@@ -1,4 +1,4 @@
-class ShellRunner
+class ShellRunner < HookInterface
 
   def initialize(script)
     @script = script

--- a/exporter_app/templates/manifest.html.erb
+++ b/exporter_app/templates/manifest.html.erb
@@ -1,0 +1,14 @@
+<html>
+<body>
+  <h1>Manifest</h1>
+
+  <ul>
+      <% @data.each do |file_data| %>
+        <li>
+          <%= file_data['title'] %> [<%= file_data['uri'] %>]
+        </li>
+      <% end %>
+  </ul>
+
+</body>
+</html>


### PR DESCRIPTION
ManifestBuilder also implements a new `HookInterface`, also now used by ShellRunner (to force implementation of `def call(task)`).

`ManifestBuilder.new("templates/manifest.html.erb"),` is added to the job before the commit, which outputs a manifest.html to the task's `export_directory`.