### PR TITLE
Fix the manifest generation and add ead_id to the mix

### DIFF
--- a/backend/model/resource_update_monitor.rb
+++ b/backend/model/resource_update_monitor.rb
@@ -74,6 +74,7 @@ class ResourceUpdateMonitor
             adds << {
               'id' => res[:id],
               'title' => res[:title],
+              'ead_id' => res[:ead_id],
               'identifier' => JSON.parse(res[:identifier]),
               'repo_id' => res[:repo_id],
               'uri' => JSONModel(:resource).uri_for(res[:id], :repo_id => res[:repo_id]),

--- a/exporter_app/config/jobs.rb
+++ b/exporter_app/config/jobs.rb
@@ -37,7 +37,7 @@
                    ],
 
                    :after_hooks => [
-                     ErbRenderer.new("templates/manifest.html.erb", "manifest.html"),
+                     ErbRenderer.new("templates/manifest.md.erb", "README.md"),
                      ShellRunner.new("scripts/commit_workspace.sh"),
                    ]),
 

--- a/exporter_app/tasks/export_ead_task.rb
+++ b/exporter_app/tasks/export_ead_task.rb
@@ -65,7 +65,8 @@ class ExportEADTask < TaskInterface
   def exported_variables
     {
       :workspace_directory => @workspace_directory,
-      :export_directory => @export_directory
+      :export_directory => @export_directory,
+      :subdirectory => @subdirectory,
     }
   end
 
@@ -144,13 +145,16 @@ class ExportEADTask < TaskInterface
   end
 
   def create_manifest_json(item)
-    outfile = path_for_export_file("#{item[:resource_id]}", 'json')
+    outfile = path_for_export_file(item[:resource_id], 'json')
 
     File.open("#{outfile}.tmp", 'w') do |io|
       io.write({
         :resource_db_id => item[:resource_id],
+        :ead_id => item[:ead_id],
+        :identifier => JSON.parse(item[:identifier]).compact.join("."),
         :uri => item[:uri],
         :title => item[:title],
+        :ead_file => File.basename(path_for_export_file(item[:resource_id], 'xml')),
       }.to_json)
     end
 

--- a/exporter_app/tasks/lib/sqlite_work_queue.rb
+++ b/exporter_app/tasks/lib/sqlite_work_queue.rb
@@ -24,7 +24,7 @@ class SQLiteWorkQueue
   def next
     with_connection do |conn|
       prepare(conn,
-              "select id, resource_id, action, identifier, repo_id, title, uri from work_queue order by id limit 1") do |statement|
+              "select id, resource_id, action, identifier, repo_id, title, uri, ead_id from work_queue order by id limit 1") do |statement|
         rs = statement.execute_query
         while rs.next
           return {
@@ -35,6 +35,7 @@ class SQLiteWorkQueue
             :repo_id => rs.get_int(5),
             :title => rs.get_string(6),
             :uri => rs.get_string(7),
+            :ead_id => rs.get_string(8),
           }
         end
       end
@@ -168,7 +169,7 @@ class SQLiteWorkQueue
       statement.execute_update("create table if not exists work_queue" +
                                " (id integer primary key autoincrement," +
                                " action text, resource_id integer, identifier text," +
-                               " repo_id integer, title text, uri text)")
+                               " repo_id integer, title text, uri text, ead_id text)")
 
       statement.execute_update("create table if not exists status" +
                                " (key primary key, int_value integer)")

--- a/exporter_app/templates/manifest.md.erb
+++ b/exporter_app/templates/manifest.md.erb
@@ -1,0 +1,6 @@
+# Manifest
+
+EAD | EAD ID | Identifier | Title
+--- | ------ | ---------- | -----
+<% @data.each do |json| %>[<%= json['ead_file'] %>](./<%= json['ead_file'] %>) | <%= json['ead_id'] %> | <%= json['identifier'] %> | <%= json['title'] %>
+<% end %>


### PR DESCRIPTION
- Fix the manifest generation since the directory path has changed
- Add ead_id to the item and JSON manifest file
- And add a markdown template to demonstrate generation of a github friendly README.md
- Change the job to generate a README.md with a table of items