### PR TITLE
Support @aspace_backend_url with a path and ensure URI join respects it

### DIFF
--- a/exporter_app/tasks/lib/archivesspace_client.rb
+++ b/exporter_app/tasks/lib/archivesspace_client.rb
@@ -6,6 +6,7 @@ class ArchivesSpaceClient
 
   def initialize(aspace_backend_url, username, password)
     @aspace_backend_url = aspace_backend_url
+    @aspace_backend_path = "#{URI(@aspace_backend_url).path}/".gsub(/\/+$/,"/")
     @username = username
     @password = password
 
@@ -27,7 +28,7 @@ class ArchivesSpaceClient
   end
 
   def json_post(path, params)
-    uri = URI.join(@aspace_backend_url, path)
+    uri = URI.join(@aspace_backend_url, @aspace_backend_path, path.gsub(/^\//,""))
 
     request = Net::HTTP::Post.new(uri)
     request.form_data = params
@@ -51,7 +52,7 @@ class ArchivesSpaceClient
   def get(path, params)
     @session = login unless @session
 
-    uri = URI.join(@aspace_backend_url, path)
+    uri = URI.join(@aspace_backend_url, @aspace_backend_path, path.gsub(/^\//,""))
     uri.query = URI.encode_www_form(params)
 
     http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
So.. this might be a bit brute force, but it works!

The first thing we do is now check if `aspace_backend_url` has a path and store this in `aspace_backend_path`.  Also, we ensure there's a trailing `/` on the path.

So now we have something like:
```
aspace_backend_url = 'https://mydomain/my/path'
aspace_backend_path = '/my/path/'
```

Now in `get` and `post_json`, we join the incoming `path` with the aspace_backend_url and aspace_backend_path.  We remove any leading `/` from the `path` so it's treated as a relative path:
```
URI.join(@aspace_backend_url, @aspace_backend_path, path.gsub(/^\//,""))
```
For example when logging in, this would join 'https://mydomain/my/path' with '/my/path/' and 'users/login'. This results in `https://mydomain/my/path/users/login`.

When there's no aspace_backend_path (or when it's '/'), this simply becomes the root path and `users/login` is appended.
