### PR TITLE
Bucket EAD files into directories to avoid hitting GitHub file count limits

### DIFF
--- a/exporter_app/lib/erb_renderer.rb
+++ b/exporter_app/lib/erb_renderer.rb
@@ -41,20 +41,24 @@ class ErbRenderer < HookInterface
   def combined_json(path)
     json = []
 
-    json_files = File.join(path, "*.json")
+    json_files = File.join(path, "*/*.json")
 
-    Dir.glob(json_files) do |filename|
-      record_json = JSON.parse(File.read(filename))
+    Dir.glob(json_files) do |json_filename|
+      record_json = JSON.parse(File.read(json_filename))
 
       record_json['other_versions'] ||= {}
 
-      Dir.glob(File.join(path, "#{record_json.fetch('resource_db_id')}.*")).each do |file_version|
+      other_versions_glob = TaskUtils.replace_extension(json_filename, '*')
+
+      Dir.glob(other_versions_glob).each do |file_version|
         next if file_version.downcase.end_with?(".tmp")
 
         name = File.basename(file_version)
-        if File.basename(file_version) != record_json['ead_file'] && name != File.basename(filename)
+        # If we're not looking at the EAD or the JSON file...
+        if !['.json', '.xml'].include?(File.extname(file_version.downcase))
+          # Generate a label like "PDF" for this other file version
           label = File.extname(file_version) == "" ? name : File.extname(file_version).upcase[1..-1]
-          record_json['other_versions'][name] = label
+          record_json['other_versions'][TaskUtils.export_file_basename(file_version)] = label
         end
       end
 

--- a/exporter_app/lib/fop_pdf_generator.rb
+++ b/exporter_app/lib/fop_pdf_generator.rb
@@ -12,16 +12,19 @@ class FopPdfGenerator < HookInterface
     export_directory = task.exported_variables.fetch(:export_directory)
     subdirectory = task.exported_variables.fetch(:subdirectory)
 
-    full_export_path = File.join(export_directory, subdirectory)
+    json_files_to_process = json_files(File.join(export_directory, subdirectory))
 
-    json_files(full_export_path).each do |json_file|
+    @log.info("PDF generating processing #{json_files_to_process.length} files")
+
+    json_files_to_process.each do |json_file|
       begin
         json = JSON.parse(File.read(json_file))
 
-        ead_file =  File.join(full_export_path, json.fetch('ead_file'))
+        ead_file = TaskUtils.replace_extension(json_file, 'xml')
         identifier = File.basename(ead_file, '.*')
-        fop_file = File.join(full_export_path, "#{identifier}.fop")
-        pdf_file = File.join(full_export_path, "#{identifier}.pdf")
+        fop_file = TaskUtils.replace_extension(json_file, 'fop')
+        pdf_file = TaskUtils.replace_extension(json_file, 'pdf')
+
         pdf_tmp_file = "#{pdf_file}.tmp"
 
         if File.exist?(pdf_file) && File.mtime(ead_file) < File.mtime(pdf_file)
@@ -69,7 +72,7 @@ class FopPdfGenerator < HookInterface
   end
 
   def json_files(path)
-    Dir.glob(File.join(path, "*.json"))
+    Dir.glob(File.join(path, "*/*.json"))
   end
 
   private

--- a/exporter_app/tasks/export_ead_task.rb
+++ b/exporter_app/tasks/export_ead_task.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'json'
+require 'digest/sha1'
 require_relative 'task_interface'
 require_relative 'lib/xml_cleaner'
 require_relative 'lib/xsd_validator'
@@ -147,9 +148,20 @@ class ExportEADTask < TaskInterface
 
   def path_for_export_file(basename, extension = 'xml')
     output_directory = File.join(@export_directory, @subdirectory)
+
+    # Github won't display more than 1000 files per directory, so bucket our
+    # files so we don't end up with too many.
+    prefix = generate_prefix(basename)
+
+    output_directory = File.join(output_directory, prefix)
+
     FileUtils.mkdir_p(output_directory)
 
     File.join(output_directory, "#{basename}.#{extension}")
+  end
+
+  def generate_prefix(id)
+    Digest::SHA1.hexdigest(id.to_s)[0..4]
   end
 
   def download_ead(item)
@@ -223,7 +235,7 @@ class ExportEADTask < TaskInterface
         :identifier => JSON.parse(item[:identifier]).compact.join("."),
         :uri => item[:uri],
         :title => item[:title],
-        :ead_file => File.basename(path_for_export_file(item[:resource_id], 'xml')),
+        :ead_file => TaskUtils.export_file_basename(path_for_export_file(item[:resource_id], 'xml')),
       }.to_json)
     end
 

--- a/exporter_app/tasks/lib/task_utils.rb
+++ b/exporter_app/tasks/lib/task_utils.rb
@@ -1,9 +1,22 @@
 require 'uri'
+require 'pathname'
 
 class TaskUtils
 
   def self.http_url?(s)
     ['https', 'http'].include?(URI.parse(s).scheme)
+  end
+
+  # Like File.basename but preserve the prefix directory for an output file
+  def self.export_file_basename(path, extension = '')
+    orig_basename = File.basename(path, extension)
+    prefix = File.basename(File.dirname(path))
+
+    File.join(prefix, orig_basename)
+  end
+
+  def self.replace_extension(path, new_extension_sans_dot)
+    Pathname.new(path).sub_ext(".#{new_extension_sans_dot}").to_s
   end
 
 end


### PR DESCRIPTION
To make this work, we adjusted:

  * Manifest generation (to link to the subdirs)

  * PDF generation (to put things in the right spot)

  * The EAD export itself (same)