### PR TITLE
Check more broadly for updates affecting resources

### DIFF
--- a/backend/controllers/resource_updates.rb
+++ b/backend/controllers/resource_updates.rb
@@ -2,7 +2,7 @@ class ArchivesSpaceService < Sinatra::Base
 
   Endpoint.get('/resource-update-feed')
     .description("Get a list of IDs for Resources changed since a timestamp")
-    .params(["timestamp", Integer, "Timestamp of last update"],
+    .params(["timestamp", Integer, "Timestamp of last update (seconds since epoch)"],
             ["repo_id", Integer, "Repository ID", :optional => true],
             ["start_id", String, "Four-part identifier as a JSON array specifying the start of a range", :optional => true],
             ["end_id", String, "Four-part identifier as a JSON array specifying the end of a range", :optional => true],


### PR DESCRIPTION
A resource should be re-exported if it is updated directly, but also:

  * If a linked archival object is updated

  * If a linked subject or agent is updated

  * If a linked digital object is updated

  * If a linked digital object component is updated