### PR TITLE
Patch to be less eager to generate PDFs

### DIFF
--- a/exporter_app/lib/fop_pdf_generator.rb
+++ b/exporter_app/lib/fop_pdf_generator.rb
@@ -24,7 +24,7 @@ class FopPdfGenerator < HookInterface
         pdf_file = File.join(full_export_path, "#{identifier}.pdf")
         pdf_tmp_file = "#{pdf_file}.tmp"
 
-        if File.exist?(pdf_file) && File.mtime(ead_file) < File.mtime(pdf_file)
+        if File.exist?(pdf_file) && File.mtime(ead_file) <= File.mtime(pdf_file)
           # PDF doesn't need updating
           next
         end


### PR DESCRIPTION
If EAD XML mtime matches PDF mtime, assume they are a pair and we don't need to generate another PDF (previously the XML mtime had to be less than the PDF mtime).

I'm not sure if this is the fix!! But it's the only way I can see how this case might happen:

https://www.pivotaltracker.com/file_attachments/69631749/download?inline=true

What do you guys think?