### PR TITLE
Use HTTPS rather than HTTP for Handle protocol

### DIFF
--- a/exporter_app/tasks/lib/handle_client.rb
+++ b/exporter_app/tasks/lib/handle_client.rb
@@ -2,7 +2,7 @@ require 'savon'
 
 class HandleClient
 
-  HANDLE_HOST = 'http://hdl.handle.net'
+  HANDLE_HOST = 'https://hdl.handle.net'
 
   def initialize(wsdl_url, user, credential, prefix, group, handle_base)
     @wsdl_url = wsdl_url


### PR DESCRIPTION
Our central IT unit has asked that we use only HTTPS for our Handle URIs.

(Other PR was me trying out the `gh` command line utility for a PR and not noticing I had to state the target branch explicitly.)